### PR TITLE
Add 15.6 developer disk image (untested)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,6 @@
 {
+
+    "15.6": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/15.4/15.4.zip",
     "15.5": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/15.4/15.4.zip",
     "15.4.1": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/15.4/15.4.zip",
     "15.4": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/15.4/15.4.zip",

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,4 @@
 {
-
     "15.6": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/15.4/15.4.zip",
     "15.5": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/15.4/15.4.zip",
     "15.4.1": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/15.4/15.4.zip",


### PR DESCRIPTION
This adds developer disk image from 15.4 to see if it works with 15.6 beta. Currently have no devices on beta.