### PR TITLE
Add iOS 16.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,5 @@
 {
+    "16.2": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/16.1/16.1.zip",
     "16.1": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/16.0/16.0.zip",
     "16.0.3": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/16.0/16.0.zip",
     "16.0.2": "https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases/download/16.0/16.0.zip",


### PR DESCRIPTION
Should be the same as 16.1
Not sure why 16.1 is using the 16.0 image, might be the difference between the betas and final release? Someone on 16.1 final should make sure it still works 